### PR TITLE
Grammatical tweaks on French FAQ

### DIFF
--- a/fr/faq.html
+++ b/fr/faq.html
@@ -119,7 +119,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Que puis-je faire avec une carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Vous pouvez conserver votre carte Santé SMART comme registre de vos antécédents de vaccination et/ou des résultats de vos tests. Vous pouvez également choisir de le partager avec d’autres personnes si vous souhaitez leur montrer ces informations.
+                        Vous pouvez conserver votre carte Santé SMART comme registre de vos antécédents de vaccination et/ou des résultats de vos tests. Vous pouvez également choisir de la partager avec d’autres personnes si vous souhaitez leur montrer ces informations.
                     </p>
                 </div>
 
@@ -128,7 +128,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Comment puis-je obtenir une carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Les cartes santé SMART peuvent provenir de n’importe quel organisme qui possède vos renseignements cliniques, comme une pharmacie, un cabinet de médecin ou un registre d’État. Voici quelques-unes des façons que vous pouvez obtenir une carte santé SMART d’eux:
+                        Les cartes Santé SMART peuvent provenir de n’importe quel organisme qui possède vos renseignements cliniques, comme une pharmacie, un cabinet de médecin ou un registre d’État. Voici quelques-unes des façons d'obtenir une carte Santé SMART:
                         <ul>
                             <li>
                                 Une copie papier peut vous être remise par l’organisme au moment de votre visite.
@@ -137,10 +137,10 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                                 Une copie papier peut vous être envoyée par la poste par l’organisme après votre visite.
                             </li>
                             <li>
-                                Vous pouvez le télécharger à partir d’un site Web ou d’une application hébergée par l’organisation et en imprimer une copie et/ou l’enregistrer sous forme de fichier.
+                                Vous pouvez la télécharger à partir d’un site Web ou d’une application hébergée par l’organisation et en imprimer une copie et/ou l’enregistrer sous forme de fichier.
                             </li>
                             <li>
-                                Vous pouvez connecter votre dossier santé à une application qui prend en charge les cartes santé SMART.
+                                Vous pouvez connecter votre dossier santé à une application qui prend en charge les cartes Santé SMART.
                             </li>
                         </ul>
                     </p>
@@ -148,7 +148,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
 
                 <div class="row mt-3">
                     <div class="asdf"><p class="question">
-                        Je n’ai pas de carte santé SMART. Je peux en avoir une ?
+                        Je n’ai pas de carte Santé SMART. Je peux en avoir une ?
                     </p>
                 </div>
                     <p class="answer">
@@ -170,25 +170,25 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Y a-t-il des frais pour utiliser une carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Non. Il ne devrait pas y avoir de frais pour obtenir une carte santé SMART. Si vous décidez de partager votre carte Santé SMART avec quelqu’un, il ne devrait pas y avoir de frais ni pour vous ou ni pour lui.
+                        Non. Il ne devrait pas y avoir de frais pour obtenir une carte Santé SMART. Si vous décidez de partager votre carte Santé SMART, il ne devrait pas y avoir de frais ni pour vous ou ni pour le récipiendaire.
                     </p>
                 </div>
 
                 <div class="row mt-3">
                     <p class="question">
-                        Ma carte santé SMART sera-t-elle acceptée partout où on demande mon statut vaccinale ou résultats de test COVID-19?
+                        Ma carte Santé SMART sera-t-elle acceptée partout où on demande mon statut vaccinal ou mes résultats de test COVID-19?
                     </p>
                     <p class="answer">
-                        À l’heure actuelle, différentes organisations ont des règles différentes pour vérifier les vaccins ou les résultats de tests. Par exemple, les règles peuvent être différentes d’un pays à l’autre. Les cartes santé SMART sont conçues de façon à être utilisées par toute organisation qui le souhaite. Toutes les organisations devraient offrir des options aux utilisateurs qui n’ont pas ou préfèrent ne pas utiliser une carte Santé SMART.
+                        À l’heure actuelle, différentes organisations ont des règles différentes pour vérifier les vaccins ou les résultats de tests. Par exemple, les règles peuvent être différentes d’un pays à l’autre. Les cartes Santé SMART sont conçues de façon à être utilisées par toute organisation qui le souhaite. Toutes les organisations devraient offrir des options aux utilisateurs qui n’ont pas ou préfèrent ne pas utiliser une carte Santé SMART.
                     </p>
                 </div>
 
                 <div class="row mt-3">
                     <p class="question">
-                        Je ne souhaite pas utiliser une carte santé SMART. Comment puis-je me retirer du système?
+                        Je ne souhaite pas utiliser une carte Santé SMART. Comment puis-je me retirer du système?
                     </p>
                     <p class="answer">
-                        Même si vous obtenez une carte Santé SMART, vous n’avez pas l’obligation de la partager avec qui que ce soit. Choisir de partager vos renseignements est toujours sous votre contrôle et la carte santé SMART ne devrait jamais être votre seule option lorsqu’on vous demande de montrer vos antécédents de vaccination ou les résultats de vos tests.
+                        Même si vous obtenez une carte Santé SMART, vous n’avez pas l’obligation de la partager avec qui que ce soit. Choisir de partager vos renseignements est toujours sous votre contrôle et la carte Santé SMART ne devrait jamais être votre seule option lorsqu’on vous demande de montrer vos antécédents de vaccination ou les résultats de vos tests.
                     </p>
                 </div>
 
@@ -197,7 +197,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Puis-je supprimer ou détruire ma carte Santé SMART ?
                     </p>
                     <p class="answer">
-                        Vous pouvez détruire une carte santé SMART papier et/ou supprimer une carte santé SMART numérique à tout moment. Si vous changez d’avis, vous pourriez être en mesure d’obtenir une nouvelle copie de l’organisme qui vous a fourni le service de vaccination ou de test.
+                        Vous pouvez détruire une carte Santé SMART papier et/ou supprimer une carte Santé SMART numérique à tout moment. Si vous changez d’avis, vous pourriez être en mesure d’obtenir une nouvelle copie de l’organisme qui vous a fourni le service de vaccination ou de test.
                     </p>
                 </div>
 
@@ -212,7 +212,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
 
                 <div class="row mt-3">
                     <p class="question">
-                        Puis-je présenter la carte SANTÉ SMART de mon enfant ou de mes parents en leur nom?
+                        Puis-je présenter la carte SantÉ SMART de mon enfant ou de mes parents en leur nom?
                     </p>
                     <p class="answer">
                         Oui, tant que vous y êtes autorisé. Le partage d’une carte Santé SMART est similaire au partage de dossiers médicaux.
@@ -227,10 +227,10 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
 
                 <div class="row mt-3">
                     <p class="question">
-                        Comment les cartes santé SMART protègent-ils ma vie privée?
+                        Comment les cartes Santé SMART protègent-ils ma vie privée?
                     </p>
                     <p class="answer">
-                        Vos antécédents de vaccination et/ou les résultats de vos tests sont stockés directement dans la carte santé SMART sous forme de code à barres 2D (code QR) ou de fichier que vous contrôlez. Le partage de votre carte est entièrement sous votre contrôle.
+                        Vos antécédents de vaccination et/ou les résultats de vos tests sont stockés directement dans la carte Santé SMART sous forme de code à barres 2D (code QR) ou de fichier que vous contrôlez. Le partage de votre carte est entièrement sous votre contrôle.
                     </p>
                 </div>
 
@@ -248,16 +248,16 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Que faire si je perds ma carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Tout comme un fichier normal, vous pouvez enregistrer des copies de sauvegardes de votre carte santé SMART numérique. Vous pouvez également effectuer des copies d’une carte santé SMART papier. Vous pourriez être en mesure de recevoir une nouvelle carte Santé SMART de l’organisme qui possède vos dossiers. 
+                        Tout comme un fichier normal, vous pouvez enregistrer des copies de sauvegardes de votre carte Santé SMART numérique. Vous pouvez également effectuer des copies d’une carte Santé SMART papier. Vous pourriez être en mesure de recevoir une nouvelle carte Santé SMART de l’organisme qui possède vos dossiers. 
                     </p>
                 </div>
 
                 <div class="row mt-3">
                     <p class="question">
-                        Quelqu’un peut-il voler ma carte santé SMART?
+                        Quelqu’un peut-il voler ma carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Votre carte santé SMART peut être présentée par quiconque la détient. Toutefois, les cartes santé SMART doivent être contre vérifiées à l’aide d’une autre pièce d’identité, comme une carte étudiante ou un permis de conduire. 
+                        Votre carte Santé SMART peut être présentée par quiconque la détient. Toutefois, les cartes Santé SMART doivent être contre vérifiées à l’aide d’une autre pièce d’identité, comme une carte étudiante ou un permis de conduire. 
                     </p>
                 </div>
 
@@ -266,7 +266,7 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Le partage de ma carte Santé SMART divulgue-t-il des identificateurs émis par le gouvernement, comme mon numéro de sécurité sociale ou mon statut de citoyenneté?
                     </p>
                     <p class="answer">
-                        Aux États-Unis, non. La carte ne doit contenir que votre nom, votre date de naissance et des renseignements cliniques comme les résultats des tests et/ou les antécédents de vaccination. Une carte santé SMART délivrée dans un autre pays peut inclure des identificateurs couramment utilisés, selon les pratiques ou règlements locaux. 
+                        Aux États-Unis, non. La carte ne doit contenir que votre nom, votre date de naissance et des renseignements cliniques comme les résultats des tests et/ou les antécédents de vaccination. Une carte Santé SMART émise dans un autre pays peut inclure des identificateurs couramment utilisés, selon les pratiques ou règlements locaux. 
                     </p>
                 </div>
 
@@ -281,16 +281,16 @@ Une carte Santé SMART a un code à barres 2D (code QR) et peut ressembler à qu
                         Pourquoi devrais-je vouloir obtenir une carte Santé SMART?
                     </p>
                     <p class="answer">
-                        Les cartes santé SMART sont un moyen de conserver vos antécédents de vaccination et/ou les résultats de vos tests pour vos dossiers personnels et peuvent vous aider à partager facilement votre statut avec un organisme qui le demande. 
+                        Les cartes Santé SMART sont un moyen de conserver vos antécédents de vaccination et/ou les résultats de vos tests pour vos dossiers personnels et peuvent vous aider à partager facilement votre statut avec un organisme qui le demande. 
                     </p>
                 </div>
 
                 <div class="row mt-3">
                     <p class="question">
-                        En quoi la carte santé SMART est-elle différente des autres cartes santé numériques?
+                        En quoi la carte Santé SMART est-elle différente des autres cartes Santé numériques?
                     </p>
                     <p class="answer">
-                        Les cartes santé SMART sont gratuites, prêtes à l’emploi, à la disposition des organisations, ne sont pas associés à une seule organisation, société ou entité gouvernementale et ont été créés pour donner aux gens un accès simple à leurs dossiers de santé. 
+                        Les cartes Santé SMART sont gratuites, prêtes à l’emploi, à la disposition des organisations, ne sont pas associées à une seule organisation, société ou entité gouvernementale et ont été créées pour donner aux gens un accès simple à leurs dossiers de santé. 
                     </p>
                 </div>
 


### PR DESCRIPTION
Fixed typos, harmonized capitalization of "carte Santé", replaced some anglicisms:

Détails (in French, for reviewers):
 - féminisé l'usage de carte Santé
 - Mis "Santé" en majuscule partout, comme le premier usage
 - délivrée -> émise, pour éviter l'anglicisme
 - quelques autres suggestions mineures